### PR TITLE
Make the default injector configurable

### DIFF
--- a/tests/AttributeInjectorTest.phpt
+++ b/tests/AttributeInjectorTest.phpt
@@ -9,10 +9,12 @@ require_once __DIR__ . '/bootstrap.php';
 use Dakujem\Middleware\TokenManipulators;
 use Dakujem\Middleware\TokenManipulators as Man;
 use LogicException;
+use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use Slim\Psr7\Factory\RequestFactory;
 use Tester\Assert;
 use Tester\TestCase;
+use Throwable;
 use TypeError;
 
 /**
@@ -26,16 +28,16 @@ class _AttributeInjectorTest extends TestCase
 {
     public function testWriter()
     {
+        // create an empty test request
+        $request = $this->createRequest();
+
+        // sanity test (no token there)
+        Assert::same(null, $request->getAttribute('token'));
+
         // a test token ...
         $token = (object)[
             'sub' => 42,
         ];
-
-        // create an empty test request
-        $request = (new RequestFactory())->createRequest('GET', '/');
-
-        // sanity test (no token there)
-        Assert::same(null, $request->getAttribute('token'));
 
         Assert::same(
             $token,
@@ -45,47 +47,115 @@ class _AttributeInjectorTest extends TestCase
         Assert::same($token, (Man::attributeInjector('foo')(fn() => $token, $request))->getAttribute('foo'));
         Assert::same($token, (Man::attributeInjector('')(fn() => $token, $request))->getAttribute(''));
 
-        $errm = 'This will appear in the error message.';
-        $runtime = function () use ($errm) {
-            throw new RuntimeException($errm);
-        };
-        $logic = function () use ($errm) {
-            throw new LogicException($errm);
+        $errorMessage = 'This will appear in the error message.';
+        $decoderThatAlwaysThrows = function () use ($errorMessage) {
+            throw new RuntimeException($errorMessage);
         };
         Assert::same(
-            $errm,
-            (Man::attributeInjector()($runtime, $request))->getAttribute('token.error'),
+            $errorMessage,
+            (Man::attributeInjector()($decoderThatAlwaysThrows, $request))->getAttribute('token.error'),
             'The error message should be written to the \'token.error\' attribute by default.'
         );
         Assert::same(
             null,
-            (Man::attributeInjector()($runtime, $request))->getAttribute('token'),
+            (Man::attributeInjector()($decoderThatAlwaysThrows, $request))->getAttribute('token'),
             'Nothing should be written to the \'token\' attribute.'
         );
         Assert::same(
-            $errm,
-            (Man::attributeInjector('whatever', 'foo.bar')($runtime, $request))->getAttribute('foo.bar')
+            $errorMessage,
+            (Man::attributeInjector('whatever', 'foo.bar')($decoderThatAlwaysThrows, $request))->getAttribute('foo.bar')
         );
         Assert::same(
-            $errm,
-            (Man::attributeInjector('whatever', '')($runtime, $request))->getAttribute('')
+            $errorMessage,
+            (Man::attributeInjector('whatever', '')($decoderThatAlwaysThrows, $request))->getAttribute('')
+        );
+    }
+
+    public function testLogicExceptionIsNotCaught()
+    {
+        // The injector only traps `RuntimeException` errors, other errors will be unhandled:
+        $errorMessage = 'An error message.';
+        // This test uses a decoder that always throws LogicException exception.
+        Assert::throws(
+            fn() => Man::attributeInjector()(
+                function () use ($errorMessage) {
+                    throw new LogicException($errorMessage);
+                },
+                $this->createRequest()
+            ),
+            LogicException::class,
+            $errorMessage
+        );
+    }
+
+    public function testNoTokenFound()
+    {
+        // On null token (token is not found in the request by the extractors), nothing is written
+        $response = (Man::attributeInjector()(fn() => null, $this->createRequest()));
+        Assert::null($response->getAttribute('token'));
+        Assert::null($response->getAttribute('token.error'));
+    }
+
+    public function testCustomMessageRenderer()
+    {
+        $errorMessage = 'An error message.';
+        $throws = function () use ($errorMessage) {
+            throw new RuntimeException($errorMessage);
+        };
+        $request = $this->createRequest();
+
+        // Default injector message handling - no custom message producer installed.
+        Assert::same(
+            $errorMessage,
+            (Man::attributeInjector(Man::TOKEN_ATTRIBUTE_NAME, Man::ERROR_ATTRIBUTE_NAME, null)($throws, $request))->getAttribute(Man::ERROR_ATTRIBUTE_NAME),
+            'The error message must be unchanged: Exception::getMessage is used.'
         );
 
-        // The injector only traps `RuntimeException` errors, other errors will be unhandled:
-        Assert::throws(fn() => Man::attributeInjector()($logic, $request), LogicException::class, $errm);
+        // Custom injector message handling.
+        $customMessage = 'foobar';
+        $messageProducer = function (Throwable $e) use ($customMessage) {
+            return $customMessage;
+        };
+        Assert::same(
+            $customMessage,
+            (Man::attributeInjector(Man::TOKEN_ATTRIBUTE_NAME, Man::ERROR_ATTRIBUTE_NAME, $messageProducer)($throws, $request))->getAttribute(Man::ERROR_ATTRIBUTE_NAME),
+            'The custom handler will produce the message.'
+        );
 
-        // On null token (token is not found in the request by the extractors), nothing is written
-        $resp = (Man::attributeInjector()(fn() => null, $request));
-        Assert::null($resp->getAttribute('token'));
-        Assert::null($resp->getAttribute('token.error'));
+        // It is also possible to assign the exception itself to the attribute.
+        $injector = Man::attributeInjector(
+            Man::TOKEN_ATTRIBUTE_NAME,
+            Man::ERROR_ATTRIBUTE_NAME,
+            fn(Throwable $e) => $e,
+        );
+        Assert::type(
+            Throwable::class,
+            ($injector($throws, $request))->getAttribute(Man::ERROR_ATTRIBUTE_NAME),
+            'The exception will be returned.'
+        );
+        Assert::same(
+            $errorMessage,
+            ($injector($throws, $request))->getAttribute(Man::ERROR_ATTRIBUTE_NAME)->getMessage(),
+            'The original decoder-provided exception message should be accessible.'
+        );
+    }
 
-        // Type error, the first argument must be callable
-        Assert::throws(function () use ($request, $token) {
-            Man::attributeInjector()($token, $request);
+    /**
+     * Type error, the first argument must be callable
+     */
+    public function testTypeErrorsAreThrown()
+    {
+        Assert::throws(function () {
+            Man::attributeInjector()([42], $this->createRequest());
         }, TypeError::class);
-        Assert::throws(function () use ($request) {
-            Man::attributeInjector()(42, $request);
+        Assert::throws(function () {
+            Man::attributeInjector()(42, $this->createRequest());
         }, TypeError::class);
+    }
+
+    private function createRequest(): RequestInterface
+    {
+        return (new RequestFactory())->createRequest('GET', '/');
     }
 }
 


### PR DESCRIPTION
`TokenManipulators::attributeInjector` should provide a way to process the exception before injecting the error attribute, to support cases where one wants the exception, or a translated message, etc.
