### PR TITLE
Default injector message prefix removed

### DIFF
--- a/src/TokenManipulators.php
+++ b/src/TokenManipulators.php
@@ -102,14 +102,19 @@ final class TokenManipulators
             Request $request
         ) use ($attributeName, $errorAttributeName): Request {
             try {
-                // Invoke the extraction and decoding process.
-                $token = $provider();
+                // Inject the token returned by the provider to the selected attribute.
+                return $request->withAttribute(
+                    $attributeName,
+                    $provider(), // Note: The extraction and decoding process is invoked at this point.
+                );
             } catch (RuntimeException $exception) {
-                // Write error messages.
-                return $request->withAttribute($errorAttributeName, 'Token error: ' . $exception->getMessage());
+                // Catch potential runtime errors raised by the provider
+                // and write the error messages to the attribute for errors.
+                return $request->withAttribute(
+                    $errorAttributeName,
+                    $exception->getMessage(),
+                );
             }
-            // Inject the token to the attribute.
-            return $request->withAttribute($attributeName, $token);
         };
     }
 

--- a/tests/AttributeInjectorTest.phpt
+++ b/tests/AttributeInjectorTest.phpt
@@ -53,7 +53,7 @@ class _AttributeInjectorTest extends TestCase
             throw new LogicException($errm);
         };
         Assert::same(
-            "Token error: {$errm}",
+            $errm,
             (Man::attributeInjector()($runtime, $request))->getAttribute('token.error'),
             'The error message should be written to the \'token.error\' attribute by default.'
         );
@@ -63,11 +63,11 @@ class _AttributeInjectorTest extends TestCase
             'Nothing should be written to the \'token\' attribute.'
         );
         Assert::same(
-            "Token error: {$errm}",
+            $errm,
             (Man::attributeInjector('whatever', 'foo.bar')($runtime, $request))->getAttribute('foo.bar')
         );
         Assert::same(
-            "Token error: {$errm}",
+            $errm,
             (Man::attributeInjector('whatever', '')($runtime, $request))->getAttribute('')
         );
 

--- a/tests/ComplexInteractionTest.phpt
+++ b/tests/ComplexInteractionTest.phpt
@@ -121,12 +121,12 @@ class _ComplexInteractionTest extends TestCase
         $request = $this->req()->withCookieParams(['token' => 'malformed.token']);
         self::check($mw(), $request, function (Request $request) {
             Assert::null($request->getAttribute('token'));        // no token and an error is present
-            Assert::same('Token error: Wrong number of segments', $request->getAttribute('token.error'));
+            Assert::same('Wrong number of segments', $request->getAttribute('token.error'));
         });
         $request = $this->req()->withHeader('Authorization', 'Bearer malformed.token');
         self::check($mw(), $request, function (Request $request) {
             Assert::null($request->getAttribute('token'));        // no token and an error is present
-            Assert::same('Token error: Wrong number of segments', $request->getAttribute('token.error'));
+            Assert::same('Wrong number of segments', $request->getAttribute('token.error'));
         });
     }
 
@@ -185,7 +185,7 @@ class _ComplexInteractionTest extends TestCase
         $request = $this->req()->withHeader('Authorization', 'Bearer malformed.token'); // invalid token
         self::check($mw(), $request, $requestCheck, function (Response $response) {
             Assert::same(401, $response->getStatusCode());
-            Assert::same(json_encode(['error' => ['message' => 'Token error: Wrong number of segments']]), $response->getBody()->getContents());
+            Assert::same(json_encode(['error' => ['message' => 'Wrong number of segments']]), $response->getBody()->getContents());
         });
     }
 


### PR DESCRIPTION
Remove the opinionated `Token error: ` error message prefix:

```php
'Token error: ' . $exception->getMessage()
```
Change to:
```php
$exception->getMessage()
```

> Reasoning
>
> The token-error attribute for writing error messages is dedicated for the purpose of writing token errors, there should be no need to prefix the messages with the obvious. To convey the message to the end users, the front-facing code should be responsible for such prefixing, if needed.